### PR TITLE
Add support for deb822 APT sources

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -26,6 +26,7 @@
 * [`apt::ppa`](#apt--ppa): Manages PPA repositories using `add-apt-repository`. Not supported on Debian.
 * [`apt::setting`](#apt--setting): Manages Apt configuration files.
 * [`apt::source`](#apt--source): Manages the Apt sources in /etc/apt/sources.list.d/.
+* [`apt::source_deb822`](#apt--source_deb822): Manage deb822 formatted APT sources under `/etc/apt/sources.list.d`
 
 ### Resource types
 
@@ -1180,6 +1181,156 @@ Data type: `Boolean`
 Specifies whether to check if the package release date is valid. Defaults to `True`.
 
 Default value: `true`
+
+### <a name="apt--source_deb822"></a>`apt::source_deb822`
+
+Manage deb822 formatted APT sources under `/etc/apt/sources.list.d`
+
+#### Examples
+
+##### Manage the Puppetlabs repo
+
+```puppet
+apt::source_deb822 { 'Puppetlabs-puppet':
+  comment    => 'Manage the puppetlabs repo',
+  enabled    => true,
+  types      => ['deb'],
+  uris       => ['http://apt.puppet.com'],
+  suites     => ['jammy'],
+  components => ['puppet8'],
+  signed_by  => ['/etc/apt/keyrings/linuxembl-ebi.gpg'],
+}
+```
+
+##### Ensure absence of a repo
+
+```puppet
+apt::source_deb822 { 'testing123':
+  ensure => 'absent',
+}
+```
+
+#### Parameters
+
+The following parameters are available in the `apt::source_deb822` defined type:
+
+* [`notify_update`](#-apt--source_deb822--notify_update)
+* [`ensure`](#-apt--source_deb822--ensure)
+* [`enabled`](#-apt--source_deb822--enabled)
+* [`comment`](#-apt--source_deb822--comment)
+* [`types`](#-apt--source_deb822--types)
+* [`uris`](#-apt--source_deb822--uris)
+* [`suites`](#-apt--source_deb822--suites)
+* [`components`](#-apt--source_deb822--components)
+* [`architectures`](#-apt--source_deb822--architectures)
+* [`allow_insecure`](#-apt--source_deb822--allow_insecure)
+* [`repo_trusted`](#-apt--source_deb822--repo_trusted)
+* [`check_valid_until`](#-apt--source_deb822--check_valid_until)
+* [`signed_by`](#-apt--source_deb822--signed_by)
+
+##### <a name="-apt--source_deb822--notify_update"></a>`notify_update`
+
+Data type: `Boolean`
+
+Specifies whether to trigger an `apt-get update` run.
+
+Default value: `true`
+
+##### <a name="-apt--source_deb822--ensure"></a>`ensure`
+
+Data type: `Enum['present','absent']`
+
+Specifies whether the Apt source file should exist.
+
+Default value: `'present'`
+
+##### <a name="-apt--source_deb822--enabled"></a>`enabled`
+
+Data type: `Boolean`
+
+Enable or Disable the APT source.
+
+Default value: `true`
+
+##### <a name="-apt--source_deb822--comment"></a>`comment`
+
+Data type: `String`
+
+Provide a comment to the APT source file.
+
+Default value: `$name`
+
+##### <a name="-apt--source_deb822--types"></a>`types`
+
+Data type: `Array[Enum['deb','deb-src'], 1, 2]`
+
+The package types this source manages.
+
+Default value: `['deb']`
+
+##### <a name="-apt--source_deb822--uris"></a>`uris`
+
+Data type: `Optional[Array[String]]`
+
+A list of URIs for the APT source.
+
+Default value: `undef`
+
+##### <a name="-apt--source_deb822--suites"></a>`suites`
+
+Data type: `Optional[Array[String]]`
+
+A list of suites for the APT source ('jammy-updates', 'bookworm', 'stable', etc.).
+
+Default value: `undef`
+
+##### <a name="-apt--source_deb822--components"></a>`components`
+
+Data type: `Optional[Array[String]]`
+
+A list of components for the APT source ('main', 'contrib', 'non-free', etc.).
+
+Default value: `undef`
+
+##### <a name="-apt--source_deb822--architectures"></a>`architectures`
+
+Data type: `Optional[Array[String]]`
+
+A list of supported architectures for the APT source ('amd64', 'i386', etc.).
+
+Default value: `undef`
+
+##### <a name="-apt--source_deb822--allow_insecure"></a>`allow_insecure`
+
+Data type: `Optional[Boolean]`
+
+Specifies whether to allow downloads from insecure repositories.
+
+Default value: `undef`
+
+##### <a name="-apt--source_deb822--repo_trusted"></a>`repo_trusted`
+
+Data type: `Optional[Boolean]`
+
+Consider the APT source trusted, even if authentication checks fail.
+
+Default value: `undef`
+
+##### <a name="-apt--source_deb822--check_valid_until"></a>`check_valid_until`
+
+Data type: `Optional[Boolean]`
+
+Specifies whether to check if the package release date is valid.
+
+Default value: `undef`
+
+##### <a name="-apt--source_deb822--signed_by"></a>`signed_by`
+
+Data type: `Optional[Variant[Array[Stdlib::AbsolutePath],String]]`
+
+Absolute path to a file containing the PGP keyring used to sign this repository.
+
+Default value: `undef`
 
 ## Data types
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -44,6 +44,10 @@ class apt::params {
       'path' => $sources_list_d,
       'ext'  => '.list',
     },
+    'source' => {
+      'path' => $sources_list_d,
+      'ext'  => '.sources',
+    },
   }
 
   $update_defaults = {

--- a/manifests/setting.pp
+++ b/manifests/setting.pp
@@ -38,7 +38,7 @@ define apt::setting (
   $setting_type = $title_array[0]
   $base_name = join(delete_at($title_array, 0), '-')
 
-  assert_type(Pattern[/\Aconf\z/, /\Apref\z/, /\Alist\z/], $setting_type) |$a, $b| {
+  assert_type(Pattern[/\Aconf\z/, /\Apref\z/, /\Alist\z/, /\Asource\z/], $setting_type) |$a, $b| {
     fail("apt::setting resource name/title must start with either 'conf-', 'pref-' or 'list-'")
   }
 

--- a/manifests/setting.pp
+++ b/manifests/setting.pp
@@ -49,7 +49,7 @@ define apt::setting (
     }
   }
 
-  if ($setting_type == 'list') or ($setting_type == 'pref') {
+  if ($setting_type == 'list') or ($setting_type == 'pref') or ($setting_type == 'source') {
     $_priority = ''
   } else {
     $_priority = $priority

--- a/manifests/source_deb822.pp
+++ b/manifests/source_deb822.pp
@@ -1,23 +1,74 @@
-# @summary A short summary of the purpose of this defined type.
+# @summary Manage deb822 formatted APT sources under `/etc/apt/sources.list.d`
 #
-# A description of what this defined type does
+# @example Manage the Puppetlabs repo
+#   apt::source_deb822 { 'Puppetlabs-puppet':
+#     comment    => 'Manage the puppetlabs repo',
+#     enabled    => true,
+#     types      => ['deb'],
+#     uris       => ['http://apt.puppet.com'],
+#     suites     => ['jammy'],
+#     components => ['puppet8'],
+#     signed_by  => ['/etc/apt/keyrings/linuxembl-ebi.gpg'],
+#   }
 #
-# @example
-#   apt::source_deb822 { 'namevar': }
+# @example Ensure absence of a repo
+#   apt::source_deb822 { 'testing123':
+#     ensure => 'absent',
+#   }
+#
+# @param notify_update 
+#   Specifies whether to trigger an `apt-get update` run.
+#
+# @param ensure
+#   Specifies whether the Apt source file should exist.
+#
+# @param enabled
+#   Enable or Disable the APT source.
+#
+# @param comment
+#   Provide a comment to the APT source file.
+#
+# @param types
+#   The package types this source manages.
+#
+# @param uris
+#   A list of URIs for the APT source.
+#
+# @param suites
+#   A list of suites for the APT source ('jammy-updates', 'bookworm', 'stable', etc.).
+#
+# @param components
+#   A list of components for the APT source ('main', 'contrib', 'non-free', etc.).
+#
+# @param architectures
+#   A list of supported architectures for the APT source ('amd64', 'i386', etc.).
+#
+# @param allow_insecure
+#   Specifies whether to allow downloads from insecure repositories.
+#
+# @param repo_trusted
+#   Consider the APT source trusted, even if authentication checks fail.
+#
+# @param check_valid_until
+#   Specifies whether to check if the package release date is valid.
+#
+# @param signed_by
+#   Absolute path to a file containing the PGP keyring used to sign this repository.
+#
 define apt::source_deb822 (
-  String $comment = $name,
-  Boolean $enabled = true,
-  Array[Enum['deb','deb-src'], 1, 2] $types = ['deb'],
-  Boolean $notify_update = true,
   Enum['present','absent'] $ensure = 'present',
+  Boolean $notify_update = true,
+  Boolean $enabled = true,
+  String $comment = $name,
+  Array[Enum['deb','deb-src'], 1, 2] $types = ['deb'],
   Optional[Array[String]] $uris = undef,
   Optional[Array[String]] $suites = undef,
   Optional[Array[String]] $components = undef,
   Optional[Array[String]] $architectures = undef,
   Optional[Boolean] $allow_insecure = undef,
   Optional[Boolean] $repo_trusted = undef,
-  Optional[Variant[Array[Stdlib::AbsolutePath],String]] $signed_by = undef,
   Optional[Boolean] $check_valid_until = undef,
+  Optional[Variant[Array[Stdlib::AbsolutePath],String]] $signed_by = undef,
 ) {
   case $ensure {
     'present': {
@@ -41,6 +92,9 @@ define apt::source_deb822 (
     'absent': {
       $header = undef
       $source_content = undef
+    }
+    default: {
+      fail('Unexpected value for $ensure parameter.')
     }
   }
 

--- a/manifests/source_deb822.pp
+++ b/manifests/source_deb822.pp
@@ -1,0 +1,31 @@
+# @summary A short summary of the purpose of this defined type.
+#
+# A description of what this defined type does
+#
+# @example
+#   apt::source_deb822 { 'namevar': }
+define apt::source_deb822 (
+  Array[String] $uris,
+  Array[String] $suites,
+  Array[String] $components,
+  Array[Enum['deb','deb-src'], 1, 2] $types = ['deb'],
+  Enum['present','absent'] $ensure = 'present',
+  String $comment = $name,
+  Boolean $enabled = true,
+  Boolean $notify_update = true,
+  Optional[Array[String]] $architectures = undef,
+  Optional[Boolean] $allow_insecure = undef,
+  Optional[Boolean] $trusted = undef,
+  Optional[Variant[Array[Stdlib::AbsolutePath], String]] $signed_by = undef,
+  Optional[Boolean] $check_valid_until = undef,
+  Optional[Hash] $options = undef
+) {
+  $header = epp('apt/_header.epp')
+  $source_content = epp('apt/source_deb822.epp')
+
+  apt::setting { "source-${name}":
+    ensure        => $ensure,
+    content       => "${header}${source_content}",
+    notify_update => $notify_update,
+  }
+}

--- a/manifests/source_deb822.pp
+++ b/manifests/source_deb822.pp
@@ -5,23 +5,44 @@
 # @example
 #   apt::source_deb822 { 'namevar': }
 define apt::source_deb822 (
-  Array[String] $uris,
-  Array[String] $suites,
-  Array[String] $components,
-  Array[Enum['deb','deb-src'], 1, 2] $types = ['deb'],
-  Enum['present','absent'] $ensure = 'present',
   String $comment = $name,
   Boolean $enabled = true,
+  Array[Enum['deb','deb-src'], 1, 2] $types = ['deb'],
   Boolean $notify_update = true,
+  Enum['present','absent'] $ensure = 'present',
+  Optional[Array[String]] $uris = undef,
+  Optional[Array[String]] $suites = undef,
+  Optional[Array[String]] $components = undef,
   Optional[Array[String]] $architectures = undef,
   Optional[Boolean] $allow_insecure = undef,
-  Optional[Boolean] $trusted = undef,
-  Optional[Variant[Array[Stdlib::AbsolutePath], String]] $signed_by = undef,
+  Optional[Boolean] $repo_trusted = undef,
+  Optional[Variant[Array[Stdlib::AbsolutePath],String]] $signed_by = undef,
   Optional[Boolean] $check_valid_until = undef,
-  Optional[Hash] $options = undef
 ) {
-  $header = epp('apt/_header.epp')
-  $source_content = epp('apt/source_deb822.epp')
+  case $ensure {
+    'present': {
+      $header = epp('apt/_header.epp')
+      $source_content = epp('apt/source_deb822.epp', delete_undef_values({
+            'uris'              => $uris,
+            'suites'            => $suites,
+            'components'        => $components,
+            'types'             => $types,
+            'comment'           => $comment,
+            'enabled'           => $enabled ? { true => 'yes', false => 'no' },
+            'architectures'     => $architectures,
+            'allow_insecure'    => $allow_insecure ? { true => 'yes', false => 'no', default => undef },
+            'repo_trusted'      => $repo_trusted ? { true => 'yes', false => 'no', default => undef },
+            'check_valid_until' => $check_valid_until ? { true => 'yes', false => 'no', default => undef },
+            'signed_by'         => $signed_by,
+          }
+        )
+      )
+    }
+    'absent': {
+      $header = undef
+      $source_content = undef
+    }
+  }
 
   apt::setting { "source-${name}":
     ensure        => $ensure,

--- a/spec/defines/source_deb822_spec.rb
+++ b/spec/defines/source_deb822_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'apt::source_deb822' do
+  let(:title) { 'namevar' }
+  let(:params) do
+    {}
+  end
+
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      it { is_expected.to compile }
+    end
+  end
+end

--- a/templates/source_deb822.epp
+++ b/templates/source_deb822.epp
@@ -1,6 +1,7 @@
 <% | String $comment,
   Enum['yes','no'] $enabled,
-  Hash $types,Array[String] $uris,
+  Array[String] $types,
+  Array[String] $uris,
   Array[String] $suites,
   Array[String] $components,
   Optional[Array] $architectures = undef,
@@ -10,10 +11,9 @@
   Optional[Variant[Array[String], String]] $signed_by = undef,
   Optional[Hash] $options = undef
 | -%>
-# This file is managed by Puppet. DO NOT EDIT.
 # <%= $comment %>
 Enabled: <%= $enabled %>
-Types:<% if $types['deb'] { %> deb<% } %><% if $types['src'] { %> deb-src<% } %>
+Types: <% $types.each |String $type| { -%> <%= $type %> <% } %>
 URIs: <% $uris.each | String $uri | { -%> <%= $uri %> <% } %>
 Suites: <% $suites.each | String $suite | { -%> <%= $suite %> <% } %>
 Components: <% $components.each | String $component | { -%> <%= $component %> <% } %>
@@ -35,9 +35,3 @@ Signed-By: <% if type($signed_by) =~ Type[Array] { -%><%- $signed_by.each |Strin
 <%- elsif type($signed_by) =~ Type[String] { %>
  <%= $signed_by -%>
 <%- }} -%>
-<% if $options { -%>
-# Additional Options
-<% $options.each |$key, $value| {-%>
-<%= $key -%>: <%= $value %>
-<% } -%>
-<% } -%>

--- a/templates/source_deb822.epp
+++ b/templates/source_deb822.epp
@@ -1,0 +1,43 @@
+<% | String $comment,
+  Enum['yes','no'] $enabled,
+  Hash $types,Array[String] $uris,
+  Array[String] $suites,
+  Array[String] $components,
+  Optional[Array] $architectures = undef,
+  Optional[Enum['yes','no']] $allow_insecure = undef,
+  Optional[Enum['yes','no']] $repo_trusted = undef,
+  Optional[Enum['yes','no']] $check_valid_until = undef,
+  Optional[Variant[Array[String], String]] $signed_by = undef,
+  Optional[Hash] $options = undef
+| -%>
+# This file is managed by Puppet. DO NOT EDIT.
+# <%= $comment %>
+Enabled: <%= $enabled %>
+Types:<% if $types['deb'] { %> deb<% } %><% if $types['src'] { %> deb-src<% } %>
+URIs: <% $uris.each | String $uri | { -%> <%= $uri %> <% } %>
+Suites: <% $suites.each | String $suite | { -%> <%= $suite %> <% } %>
+Components: <% $components.each | String $component | { -%> <%= $component %> <% } %>
+<% if $architectures { -%>
+Architectures:<% $architectures.each | String $arch | { %> <%= $arch %><% } %>
+<%- } -%>
+<% if $allow_insecure { -%>
+Allow-Insecure: <%= $allow_insecure %>
+<% } -%>
+<% if $repo_trusted { -%>
+Trusted: <%= $repo_trusted %>
+<% } -%>
+<% if $check_valid_until { -%>
+Check-Valid-Until: <%= $check_valid_until %>
+<% } -%>
+<% if $signed_by { -%>
+Signed-By: <% if type($signed_by) =~ Type[Array] { -%><%- $signed_by.each |String $keyring| { -%><%= $keyring %> <% } %>
+<%- } -%>
+<%- elsif type($signed_by) =~ Type[String] { %>
+ <%= $signed_by -%>
+<%- }} -%>
+<% if $options { -%>
+# Additional Options
+<% $options.each |$key, $value| {-%>
+<%= $key -%>: <%= $value %>
+<% } -%>
+<% } -%>

--- a/templates/source_deb822.epp
+++ b/templates/source_deb822.epp
@@ -9,7 +9,6 @@
   Optional[Enum['yes','no']] $repo_trusted = undef,
   Optional[Enum['yes','no']] $check_valid_until = undef,
   Optional[Variant[Array[String], String]] $signed_by = undef,
-  Optional[Hash] $options = undef
 | -%>
 # <%= $comment %>
 Enabled: <%= $enabled %>


### PR DESCRIPTION
## Summary
Add new defined type (apt::source_deb822) for generating [deb822 APT sources](https://manpages.debian.org/unstable/apt/sources.list.5.en.html#DEB822-STYLE_FORMAT)

## Additional Context
- deb822 APT sources will eventually (no specific timeline) replace the existing sources.list format
- Ubuntu 24.04 will ship with the Ubuntu repo configuration in deb822 format
- The current module does not have a way to manage deb822 `.sources` files

## Related Issues (if any)
N/A

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)